### PR TITLE
Update README.md for clarity on shorthand includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ list               | Show contents of archive
 
 | _Option_                      | _Description_
 |-------------------------------|--------------
---includes             | Select all Qubes VMs marked as "include in backups". (backup)
+--includes, -i             | Select all Qubes VMs marked as "include in backups". (backup)
 --exclude=qube_name    | Exclude a specific VM from the operation (backup, restore, verify
 --dedup, -d            | Use deduplication. (backup)
 --session=_date-time[,date-time]_ | Select a session or session range by date-time or tag (restore, list, prune).


### PR DESCRIPTION
Added `, -i` to signify short-hard for --includes as it is used in the usage `backup [-i]` but not stated in the parameters.